### PR TITLE
Add missing dependency towards bigarray (was a separate library before OCaml 4.08)

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
  (name opus)
  (public_name opus)
  (synopsis "OCaml bindings for libopus")
- (libraries ogg)
+ (libraries bigarray ogg)
  (modules opus)
  (foreign_stubs
   (language c)


### PR DESCRIPTION
The issue can be shown in your tests (see https://github.com/ocaml/opam-repository/pull/21682):
```
#=== ERROR while compiling opus.0.2.2 =========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.07.1 | pinned(https://github.com/savonet/ocaml-opus/archive/v0.2.2.tar.gz)
# path                 ~/.opam/4.07/.opam-switch/build/opus.0.2.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p opus -j 31 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/opus-35-4e3c1b.env
# output-file          ~/.opam/log/opus-35-4e3c1b.out
### output ###
# (cd _build/default && /home/opam/.opam/4.07/bin/ocamlopt.opt -w -40 -g -o examples/opus2wav.exe /home/opam/.opam/4.07/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ogg/ogg.cmxa -I /home/opam/.opam/4.07/lib/ogg src/opus.cmxa -I src examples/.opus2wav.eobjs/native/dune__exe__Opus2wav.cmx)
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Bigarray referenced from examples/.opus2wav.eobjs/native/dune__exe__Opus2wav.cmx
# (cd _build/default && /home/opam/.opam/4.07/bin/ocamlopt.opt -w -40 -g -o examples/wav2opus.exe /home/opam/.opam/4.07/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ogg/ogg.cmxa -I /home/opam/.opam/4.07/lib/ogg src/opus.cmxa -I src examples/.wav2opus.eobjs/native/dune__exe__Wav2opus.cmx)
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Bigarray referenced from examples/.wav2opus.eobjs/native/dune__exe__Wav2opus.cmx
```